### PR TITLE
bug: notification don't send if one of settings disabled, but title and category both changed

### DIFF
--- a/ent/migrate/migrations/20230521162457_GameAndTitleChangeNotificationSetting.sql
+++ b/ent/migrate/migrations/20230521162457_GameAndTitleChangeNotificationSetting.sql
@@ -1,0 +1,2 @@
+-- Modify "chat_settings" table
+ALTER TABLE "chat_settings" ADD COLUMN "game_and_title_change_notification" boolean NOT NULL DEFAULT false;

--- a/ent/migrate/migrations/atlas.sum
+++ b/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,5 @@
-h1:s6faVjhzKSLK5+1hpWd2ynZNmYfSzKtZZl4OLj2LjLQ=
+h1:5dIiqHm4gM6G6fF/AjBxNMcJBJYgK25xeMdiqHT0XMk=
 20230327181912_initial.sql h1:L6nniWh3O35p6lwgIG+NrRkkU2n2iG48Be5/zfPAz0I=
 20230401125338_TitleChangeNotification.sql h1:9u5qCYBNNL6RHtLdcW691tRhYyli7/pG2kBxYuHs1fA=
 20230506114213_EnableImageInNotification.sql h1:cGbFYJRVhaB3swtBPyOmw627aemnTVRd6HByCSJa0OQ=
+20230521162457_GameAndTitleChangeNotificationSetting.sql h1:g1bUjbU8y2uGqbiDh89URK3QWv+XBRYC4rwsW6Zu408=

--- a/ent/schema/chat_settings.go
+++ b/ent/schema/chat_settings.go
@@ -27,6 +27,7 @@ func (ChatSettings) Fields() []ent.Field {
 		field.UUID("id", uuid.UUID{}).Default(uuid.New),
 		field.Bool("game_change_notification").Default(true),
 		field.Bool("title_change_notification").Default(false),
+		field.Bool("game_and_title_change_notification").Default(false),
 		field.Bool("offline_notification").Default(true),
 		field.Bool("image_in_notification").Default(true),
 		field.Enum("chat_language").

--- a/internal/db/chat.go
+++ b/internal/db/chat.go
@@ -7,11 +7,12 @@ import (
 )
 
 type ChatUpdateSettingsQuery struct {
-	GameChangeNotification  *bool
-	OfflineNotification     *bool
-	TitleChangeNotification *bool
-	ImageInNotification     *bool
-	ChatLanguage            *db_models.ChatLanguage
+	GameChangeNotification         *bool
+	OfflineNotification            *bool
+	TitleChangeNotification        *bool
+	GameAndTitleChangeNotification *bool
+	ImageInNotification            *bool
+	ChatLanguage                   *db_models.ChatLanguage
 }
 
 type ChatUpdateQuery struct {

--- a/internal/db/chat_ent_impl.go
+++ b/internal/db/chat_ent_impl.go
@@ -15,13 +15,14 @@ type chatService struct {
 
 func (c *chatService) convertEntity(entity *ent.Chat) *db_models.Chat {
 	settings := &db_models.ChatSettings{
-		ID:                      entity.Edges.Settings.ID,
-		GameChangeNotification:  entity.Edges.Settings.GameChangeNotification,
-		OfflineNotification:     entity.Edges.Settings.OfflineNotification,
-		TitleChangeNotification: entity.Edges.Settings.TitleChangeNotification,
-		ImageInNotification:     entity.Edges.Settings.ImageInNotification,
-		ChatLanguage:            db_models.ChatLanguage(entity.Edges.Settings.ChatLanguage),
-		ChatID:                  entity.Edges.Settings.ChatID,
+		ID:                             entity.Edges.Settings.ID,
+		GameChangeNotification:         entity.Edges.Settings.GameChangeNotification,
+		OfflineNotification:            entity.Edges.Settings.OfflineNotification,
+		TitleChangeNotification:        entity.Edges.Settings.TitleChangeNotification,
+		GameAndTitleChangeNotification: entity.Edges.Settings.GameAndTitleChangeNotification,
+		ImageInNotification:            entity.Edges.Settings.ImageInNotification,
+		ChatLanguage:                   db_models.ChatLanguage(entity.Edges.Settings.ChatLanguage),
+		ChatID:                         entity.Edges.Settings.ChatID,
 	}
 
 	return &db_models.Chat{
@@ -68,6 +69,10 @@ func (c *chatService) Update(
 
 		if settings.Settings.ImageInNotification != nil {
 			updater.SetImageInNotification(*settings.Settings.ImageInNotification)
+		}
+
+		if settings.Settings.GameAndTitleChangeNotification != nil {
+			updater.SetGameAndTitleChangeNotification(*settings.Settings.GameAndTitleChangeNotification)
 		}
 
 		_, err = updater.Save(ctx)

--- a/internal/db/db_models/chat.go
+++ b/internal/db/db_models/chat.go
@@ -46,11 +46,12 @@ func (cl ChatLanguage) String() string {
 }
 
 type ChatSettings struct {
-	ID                      uuid.UUID    `json:"id,omitempty"`
-	GameChangeNotification  bool         `json:"game_change_notification,omitempty"`
-	TitleChangeNotification bool         `json:"title_change_notification,omitempty"`
-	OfflineNotification     bool         `json:"offline_notification,omitempty"`
-	ChatLanguage            ChatLanguage `json:"chat_language,omitempty"`
-	ChatID                  uuid.UUID    `json:"chat_id,omitempty"`
-	ImageInNotification     bool         `json:"image_in_notification,omitempty"`
+	ID                             uuid.UUID    `json:"id,omitempty"`
+	GameChangeNotification         bool         `json:"game_change_notification,omitempty"`
+	TitleChangeNotification        bool         `json:"title_change_notification,omitempty"`
+	GameAndTitleChangeNotification bool         `json:"game_and_title_change_notification,omitempty"`
+	OfflineNotification            bool         `json:"offline_notification,omitempty"`
+	ChatLanguage                   ChatLanguage `json:"chat_language,omitempty"`
+	ChatID                         uuid.UUID    `json:"chat_id,omitempty"`
+	ImageInNotification            bool         `json:"image_in_notification,omitempty"`
 }

--- a/internal/db/follow_ent_impl.go
+++ b/internal/db/follow_ent_impl.go
@@ -41,10 +41,11 @@ func (f *followService) convertEntity(follow *ent.Follow) *db_models.Follow {
 			ChatLanguage: db_models.ChatLanguage(
 				follow.Edges.Chat.Edges.Settings.ChatLanguage,
 			),
-			GameChangeNotification:  follow.Edges.Chat.Edges.Settings.GameChangeNotification,
-			TitleChangeNotification: follow.Edges.Chat.Edges.Settings.TitleChangeNotification,
-			OfflineNotification:     follow.Edges.Chat.Edges.Settings.OfflineNotification,
-			ImageInNotification:     follow.Edges.Chat.Edges.Settings.ImageInNotification,
+			GameChangeNotification:         follow.Edges.Chat.Edges.Settings.GameChangeNotification,
+			TitleChangeNotification:        follow.Edges.Chat.Edges.Settings.TitleChangeNotification,
+			OfflineNotification:            follow.Edges.Chat.Edges.Settings.OfflineNotification,
+			ImageInNotification:            follow.Edges.Chat.Edges.Settings.ImageInNotification,
+			GameAndTitleChangeNotification: follow.Edges.Chat.Edges.Settings.GameAndTitleChangeNotification,
 		}
 
 		convertedFollow.Chat = &db_models.Chat{

--- a/internal/telegram/commands/start_test.go
+++ b/internal/telegram/commands/start_test.go
@@ -55,7 +55,7 @@ func TestStartCommand_buildKeyboard(t *testing.T) {
 
 	keyboard := cmd.buildKeyboard(ctx)
 
-	const buttons = 6
+	const buttons = 7
 	assert.Equal(t, buttons, len(keyboard.InlineKeyboard))
 
 	assert.Equal(
@@ -78,18 +78,24 @@ func TestStartCommand_buildKeyboard(t *testing.T) {
 
 	assert.Equal(
 		t,
-		"image_in_notification_setting",
+		"start_game_and_title_change_notification_setting",
 		keyboard.InlineKeyboard[3][0].CallbackData,
 	)
 
 	assert.Equal(
 		t,
-		"language_picker",
+		"image_in_notification_setting",
 		keyboard.InlineKeyboard[4][0].CallbackData,
 	)
 
-	assert.Equal(t, "Github", keyboard.InlineKeyboard[5][0].Text)
-	assert.Equal(t, "https://github.com/Satont/twitch-notifier", keyboard.InlineKeyboard[5][0].URL)
+	assert.Equal(
+		t,
+		"language_picker",
+		keyboard.InlineKeyboard[5][0].CallbackData,
+	)
+
+	assert.Equal(t, "Github", keyboard.InlineKeyboard[6][0].Text)
+	assert.Equal(t, "https://github.com/Satont/twitch-notifier", keyboard.InlineKeyboard[6][0].URL)
 
 	sessionManager.AssertExpectations(t)
 	i18.AssertNumberOfCalls(t, "Translate", buttons-1)

--- a/internal/twitch_streams_cheker/twitch_streams_cheker.go
+++ b/internal/twitch_streams_cheker/twitch_streams_cheker.go
@@ -229,8 +229,7 @@ func (t *TwitchStreamChecker) check(ctx context.Context) {
 					thumbNail := createThumbNail(twitchCurrentStream.ThumbnailURL)
 
 					for _, follower := range followers {
-						if !follower.Chat.Settings.GameChangeNotification ||
-							!follower.Chat.Settings.TitleChangeNotification {
+						if !follower.Chat.Settings.GameAndTitleChangeNotification {
 							continue
 						}
 

--- a/internal/twitch_streams_cheker/twitch_streams_cheker_test.go
+++ b/internal/twitch_streams_cheker/twitch_streams_cheker_test.go
@@ -2,6 +2,8 @@ package twitch_streams_cheker
 
 import (
 	"context"
+	"testing"
+
 	"github.com/google/uuid"
 	"github.com/nicklaw5/helix/v2"
 	"github.com/samber/lo"
@@ -9,10 +11,9 @@ import (
 	"github.com/satont/twitch-notifier/internal/db/db_models"
 	"github.com/satont/twitch-notifier/internal/test_utils/mocks"
 	"github.com/satont/twitch-notifier/internal/types"
-	"github.com/satont/twitch-notifier/pkg/i18n/mocks"
+	i18nmocks "github.com/satont/twitch-notifier/pkg/i18n/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"testing"
 )
 
 func TestNewTwitchStreamChecker(t *testing.T) {
@@ -50,10 +51,11 @@ func TestTwitchStreamChecker_check(t *testing.T) {
 		ID:     uuid.New(),
 		ChatID: "1",
 		Settings: &db_models.ChatSettings{
-			ChatLanguage:           db_models.ChatLanguageEn,
-			GameChangeNotification: true,
-			OfflineNotification:    true,
-			ImageInNotification:    true,
+			ChatLanguage:                   db_models.ChatLanguageEn,
+			GameChangeNotification:         true,
+			OfflineNotification:            true,
+			ImageInNotification:            true,
+			GameAndTitleChangeNotification: false,
 		},
 	}
 	dbFollow := &db_models.Follow{

--- a/locales/en/commands/start.json
+++ b/locales/en/commands/start.json
@@ -13,5 +13,8 @@
   },
 	"image_in_notification_setting": {
 		"button": "Show images in notifications"
-	}
+	},
+  "game_and_title_change_notification_setting": {
+    "button": "Game and title change notification"
+  }
 }

--- a/locales/ru/commands/start.json
+++ b/locales/ru/commands/start.json
@@ -13,5 +13,8 @@
   },
 	"image_in_notification_setting": {
 		"button": "Показывать изображения в уведомлениях"
-	}
+	},
+  "game_and_title_change_notification_setting": {
+    "button": "Уведомелние о смене категории и названия"
+  }
 }


### PR DESCRIPTION
Resolved #104 
Changed logic of check() a little bit, so it now work more complicated if title and category changed both.
Also, I've changed abstraction level of message_sender, and now it knows about message types, what seems good idea to me and also it's simplified check method.
I didn't implement new tests for this one because it's needs a lot of work and I don't want to do it without understanding that my PR is what we need. 